### PR TITLE
Fmap infix functor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.stack-work
+
+
+stack.yaml
+stack.yaml.lock

--- a/Fmap_infix.hs
+++ b/Fmap_infix.hs
@@ -1,0 +1,9 @@
+module Fmap_infix where
+
+import RTick
+import Prelude hiding (fmap, (<$>), (<*>))
+import ProofCombinators
+
+
+fmap_infix_proof :: Tick a -> (a -> b) -> ()
+fmap_infix_proof t f = fmap f t ==. (f <$> t) *** QED

--- a/RTick.hs
+++ b/RTick.hs
@@ -88,6 +88,14 @@ instance F.Functor Tick where
 fmap :: (a -> b) -> Tick a -> Tick b
 fmap f (Tick m x) = Tick m (f x)
 
+{-@ infixl 4 <$> @-}
+{-@ (<$>) :: f:(a -> b) -> t1:Tick a
+    -> { t:Tick b | Tick (tcost t1) (f (tval t1)) == t }
+@-}
+infixl 4 <$>
+(<$>) :: (a -> b) -> Tick a -> Tick b
+(<$>) = fmap
+
 instance A.Applicative Tick where
   pure  = pure
   (<*>) = (<*>)

--- a/RTick.hs
+++ b/RTick.hs
@@ -47,6 +47,7 @@ module RTick
   , (=\<)     -- step (-1)    . (>>= f)
   , (>\\=)    -- step (-2)    . (>>= f)
   , (=\\<)    -- step (-2)    . (>>= f)
+  , (<$>)     -- fmap, but as infixl  
   -- Memoisation:
   , pay
   , zipWithM
@@ -54,7 +55,7 @@ module RTick
 
   ) where
 
-import Prelude hiding ( Functor(..), Applicative(..), Monad(..), (=<<) )
+import Prelude hiding ( Functor(..), Applicative(..), Monad(..), (=<<), (<$>) )
 
 import qualified Control.Applicative as A
 import qualified Control.Monad       as M
@@ -88,7 +89,6 @@ instance F.Functor Tick where
 fmap :: (a -> b) -> Tick a -> Tick b
 fmap f (Tick m x) = Tick m (f x)
 
-{-@ infixl 4 <$> @-}
 {-@ (<$>) :: f:(a -> b) -> t1:Tick a
     -> { t:Tick b | Tick (tcost t1) (f (tval t1)) == t }
 @-}


### PR DESCRIPTION
ADDED: fmap infix operator <$>

<$> is commonly known by haskell developers and is documented here: https://hackage.haskell.org/package/base-4.18.0.0/docs/Prelude.html#v:-60--36--62-

example usage: 
```haskell
myfunc :: a -> Tree a -> Tree a -> Tick (Tree a)
myfunc a l r = Tree <$> (pure a) <*> l <*> r
```

